### PR TITLE
Fix modem not registered for roaming

### DIFF
--- a/check_sms3status.pl
+++ b/check_sms3status.pl
@@ -163,7 +163,7 @@ while (<IN>) {
 	if (/\+CSQ:\s*(\d+),(\d+)/) { $signal = $1; $sigber = $2 };
     if (/\+COPS:\s*\d+,\d+,\"(.*)\"/) { $netz = $1 }
 	elsif (/\+COPS:\s*\d+,\d+,([^ ]*)/) { $netz = $1 };
-	if (!/\+CREG:\s*(\d,1)/) { $unreg = TRUE };
+	if (!/\+CREG:\s*(\d,(1|5))/) { $unreg = TRUE };
 
 
 	$sigdb = ((2*$signal)-113);


### PR DESCRIPTION
I was getting errors on my setup, because i roam between O2 and E-Plus network in germany
this small change fixed it